### PR TITLE
beta to stable, versions adjusted

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,6 +114,7 @@ RUN set -x && \
     ln -sf /dev/stderr /var/log/nginx/error.log && \
     # Make PageSpeed cache writabl:
     mkdir -p /var/cache/ngx_pagespeed && \
+    chown -R nginx:nginx /var/cache/ngx_pagespeed && \
     chmod -R o+wr /var/cache/ngx_pagespeed && \
     # PageSpeed log dir:
     mkdir -p /var/log/pagespeed && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,8 @@ RUN set -x && \
         --without-http_upstream_ip_hash_module \
         --prefix=/etc/nginx \
         --conf-path=/etc/nginx/nginx.conf \
+        --http-log-path=/var/log/nginx/access.log \
+        --error-log-path=/var/log/nginx/error.log \
         --pid-path=/var/run/nginx.pid \
         --add-module=/tmp/ngx_pagespeed-${PAGESPEED_VERSION}-${PAGESPEED_BRANCH} \
         --with-cc-opt="-fPIC -I /usr/include/apr-1" \
@@ -109,9 +111,12 @@ RUN set -x && \
     cd && \
     apk del .build-deps && \
     rm -rf /tmp/* && \
+    # forward request and error logs to docker log collector
+    ln -sf /dev/stdout /var/log/nginx/access.log && \
+    ln -sf /dev/stderr /var/log/nginx/error.log && \
     # Make PageSpeed cache writabl:
-    mkdir -p /var/cache/pagespeed && \
-    chmod -R o+wr /var/cache/pagespeed && \
+    mkdir -p /var/cache/ngx_pagespeed && \
+    chmod -R o+wr /var/cache/ngx_pagespeed && \
     # PageSpeed log dir:
     mkdir -p /var/log/pagespeed && \
     chmod -R o+wr /var/log/pagespeed

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,18 @@ FROM alpine:3.6
 
 # Inspired by wernight/docker-alpine-nginx-pagespeed
 
+ENV PAGESPEED_VERSION 1.12.34.3
+ENV PAGESPEED_BRANCH stable
+ENV NGINX_VERSION 1.12.2
+ENV LIBPNG_VERSION 1.2.59
+
 RUN apk --no-cache add \
         ca-certificates \
         libuuid \
         apr \
         apr-util \
         libjpeg-turbo \
+        libwebp \
         icu \
         icu-libs \
         openssl \
@@ -23,27 +29,26 @@ RUN set -x && \
         curl \
         icu-dev \
         libjpeg-turbo-dev \
+        libwebp-dev \
         linux-headers \
         gperf \
         libressl-dev \
         pcre-dev \
         python \
         zlib-dev && \
+    # Nginx user & group
+    addgroup -S nginx && \
+    adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx && \
     # Build libpng:
-    # This sadly requires an old version of http://www.libpng.org/pub/png/libpng.html
-    LIBPNG_VERSION=1.2.59 && \
     cd /tmp && \
     curl -L http://prdownloads.sourceforge.net/libpng/libpng-${LIBPNG_VERSION}.tar.gz | tar -zx && \
     cd /tmp/libpng-${LIBPNG_VERSION} && \
     ./configure --build=$CBUILD --host=$CHOST --prefix=/usr --enable-shared --with-libpng-compat && \
     make install V=0 && \
     # Build PageSpeed:
-    # Check https://github.com/pagespeed/ngx_pagespeed/releases for the latest version
-    PAGESPEED_VERSION=1.12.34.3 && \
-    NGX_PAGESPEED_VERSION=1.12.34.3 && \
     cd /tmp && \
-    curl -L https://github.com/We-Amp/ngx-pagespeed-alpine/blob/master/mod-pagespeed-stable-1.12.34.3.tar.bz2?raw=true | tar -jx && \
-    curl -L https://github.com/pagespeed/ngx_pagespeed/archive/v${NGX_PAGESPEED_VERSION}-stable.tar.gz | tar -zx && \
+    curl -L https://github.com/We-Amp/ngx-pagespeed-alpine/blob/master/mod-pagespeed-beta-${PAGESPEED_VERSION}.tar.bz2?raw=true | tar -jx && \
+    curl -L https://github.com/pagespeed/ngx_pagespeed/archive/v${PAGESPEED_VERSION}-${PAGESPEED_BRANCH}.tar.gz | tar -zx && \
     cd /tmp/modpagespeed-${PAGESPEED_VERSION} && \
     curl -L https://raw.githubusercontent.com/We-Amp/ngx-pagespeed-alpine/master/patches/automatic_makefile.patch | patch -p1 && \
     curl -L https://raw.githubusercontent.com/We-Amp/ngx-pagespeed-alpine/master/patches/libpng_cflags.patch | patch -p1 && \
@@ -55,27 +60,27 @@ RUN set -x && \
     make BUILDTYPE=Release CXXFLAGS=" -I/usr/include/apr-1 -I/tmp/libpng-${LIBPNG_VERSION} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0" CFLAGS=" -I/usr/include/apr-1 -I/tmp/libpng-${LIBPNG_VERSION} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0" -j4 && \
     cd /tmp/modpagespeed-${PAGESPEED_VERSION}/src/pagespeed/automatic/ && \
     make psol BUILDTYPE=Release CXXFLAGS=" -I/usr/include/apr-1 -I/tmp/libpng-${LIBPNG_VERSION} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0" CFLAGS=" -I/usr/include/apr-1 -I/tmp/libpng-${LIBPNG_VERSION} -fPIC -D_GLIBCXX_USE_CXX11_ABI=0" && \
-    mkdir -p /tmp/ngx_pagespeed-${NGX_PAGESPEED_VERSION}-stable/psol && \
-    mkdir -p /tmp/ngx_pagespeed-${NGX_PAGESPEED_VERSION}-stable/psol/lib/Release/linux/x64 && \
-    mkdir -p /tmp/ngx_pagespeed-${NGX_PAGESPEED_VERSION}-stable/psol/include/out/Release && \
-    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/out/Release/obj /tmp/ngx_pagespeed-${NGX_PAGESPEED_VERSION}-stable/psol/include/out/Release/ && \
-    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/net /tmp/ngx_pagespeed-${NGX_PAGESPEED_VERSION}-stable/psol/include/ && \
-    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/testing /tmp/ngx_pagespeed-${NGX_PAGESPEED_VERSION}-stable/psol/include/ && \
-    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/pagespeed /tmp/ngx_pagespeed-${NGX_PAGESPEED_VERSION}-stable/psol/include/ && \
-    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/third_party /tmp/ngx_pagespeed-${NGX_PAGESPEED_VERSION}-stable/psol/include/ && \
-    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/tools /tmp/ngx_pagespeed-${NGX_PAGESPEED_VERSION}-stable/psol/include/ && \
-    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/pagespeed/automatic/pagespeed_automatic.a /tmp/ngx_pagespeed-${NGX_PAGESPEED_VERSION}-stable/psol/lib/Release/linux/x64 && \
-    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/url /tmp/ngx_pagespeed-${NGX_PAGESPEED_VERSION}-stable/psol/include/ && \
+    mkdir -p /tmp/ngx_pagespeed-${PAGESPEED_VERSION}-${PAGESPEED_BRANCH}/psol && \
+    mkdir -p /tmp/ngx_pagespeed-${PAGESPEED_VERSION}-${PAGESPEED_BRANCH}/psol/lib/Release/linux/x64 && \
+    mkdir -p /tmp/ngx_pagespeed-${PAGESPEED_VERSION}-${PAGESPEED_BRANCH}/psol/include/out/Release && \
+    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/out/Release/obj /tmp/ngx_pagespeed-${PAGESPEED_VERSION}-${PAGESPEED_BRANCH}/psol/include/out/Release/ && \
+    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/net /tmp/ngx_pagespeed-${PAGESPEED_VERSION}-${PAGESPEED_BRANCH}/psol/include/ && \
+    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/testing /tmp/ngx_pagespeed-${PAGESPEED_VERSION}-${PAGESPEED_BRANCH}/psol/include/ && \
+    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/pagespeed /tmp/ngx_pagespeed-${PAGESPEED_VERSION}-${PAGESPEED_BRANCH}/psol/include/ && \
+    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/third_party /tmp/ngx_pagespeed-${PAGESPEED_VERSION}-${PAGESPEED_BRANCH}/psol/include/ && \
+    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/tools /tmp/ngx_pagespeed-${PAGESPEED_VERSION}-${PAGESPEED_BRANCH}/psol/include/ && \
+    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/pagespeed/automatic/pagespeed_automatic.a /tmp/ngx_pagespeed-${PAGESPEED_VERSION}-${PAGESPEED_BRANCH}/psol/lib/Release/linux/x64 && \
+    cp -r /tmp/modpagespeed-${PAGESPEED_VERSION}/src/url /tmp/ngx_pagespeed-${PAGESPEED_VERSION}-${PAGESPEED_BRANCH}/psol/include/ && \
     # Build Nginx with support for PageSpeed:
-    # Check http://nginx.org/en/download.html for the latest version.
-    NGINX_VERSION=1.12.2 && \
     cd /tmp && \
     curl -L http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz | tar -zx && \
     cd /tmp/nginx-${NGINX_VERSION} && \
-    ./configure --with-ipv6 \
+    ./configure \
         --prefix=/var/lib/nginx \
         --sbin-path=/usr/sbin \
         --modules-path=/usr/lib/nginx \
+        --user=nginx \
+        --group=nginx \
         --with-http_ssl_module \
         --with-http_gzip_static_module \
         --with-file-aio \
@@ -95,25 +100,24 @@ RUN set -x && \
         --without-http_upstream_ip_hash_module \
         --prefix=/etc/nginx \
         --conf-path=/etc/nginx/nginx.conf \
-        --http-log-path=/var/log/nginx/access.log \
-        --error-log-path=/var/log/nginx/error.log \
         --pid-path=/var/run/nginx.pid \
-        --add-module=/tmp/ngx_pagespeed-${NGX_PAGESPEED_VERSION}-stable \
+        --add-module=/tmp/ngx_pagespeed-${PAGESPEED_VERSION}-${PAGESPEED_BRANCH} \
         --with-cc-opt="-fPIC -I /usr/include/apr-1" \
-        --with-ld-opt="-Wl,--start-group -luuid -lapr-1 -laprutil-1 -licudata -licuuc -lpng12 -lturbojpeg -ljpeg" && \
+        --with-ld-opt="-Wl,--start-group -luuid -lapr-1 -laprutil-1 -licudata -licuuc -lpng12 -lturbojpeg -ljpeg -lwebp" && \
     make install --silent && \
     # Clean-up:
     cd && \
     apk del .build-deps && \
     rm -rf /tmp/* && \
-    # forward request and error logs to docker log collector
-    ln -sf /dev/stdout /var/log/nginx/access.log && \
-    ln -sf /dev/stderr /var/log/nginx/error.log && \
     # Make PageSpeed cache writabl:
-    mkdir -p /var/cache/ngx_pagespeed && \
-    chmod -R o+wr /var/cache/ngx_pagespeed
+    mkdir -p /var/cache/pagespeed && \
+    chmod -R o+wr /var/cache/pagespeed && \
+    # PageSpeed log dir:
+    mkdir -p /var/log/pagespeed && \
+    chmod -R o+wr /var/log/pagespeed
 
 EXPOSE 80 443
 
-CMD ["nginx", "-g", "daemon off;"]
+STOPSIGNAL SIGTERM
 
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN apk --no-cache add \
         apr \
         apr-util \
         libjpeg-turbo \
-        libwebp \
         icu \
         icu-libs \
         openssl \
@@ -29,7 +28,6 @@ RUN set -x && \
         curl \
         icu-dev \
         libjpeg-turbo-dev \
-        libwebp-dev \
         linux-headers \
         gperf \
         libressl-dev \
@@ -105,7 +103,7 @@ RUN set -x && \
         --pid-path=/var/run/nginx.pid \
         --add-module=/tmp/ngx_pagespeed-${PAGESPEED_VERSION}-${PAGESPEED_BRANCH} \
         --with-cc-opt="-fPIC -I /usr/include/apr-1" \
-        --with-ld-opt="-Wl,--start-group -luuid -lapr-1 -laprutil-1 -licudata -licuuc -lpng12 -lturbojpeg -ljpeg -lwebp" && \
+        --with-ld-opt="-Wl,--start-group -luuid -lapr-1 -laprutil-1 -licudata -licuuc -lpng12 -lturbojpeg -ljpeg" && \
     make install --silent && \
     # Clean-up:
     cd && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN set -x && \
     PAGESPEED_VERSION=1.12.34.3 && \
     NGX_PAGESPEED_VERSION=1.12.34.3 && \
     cd /tmp && \
-    curl -L https://github.com/We-Amp/ngx-pagespeed-alpine/blob/master/mod-pagespeed-beta-1.12.34.3.tar.bz2?raw=true | tar -jx && \
+    curl -L https://github.com/We-Amp/ngx-pagespeed-alpine/blob/master/mod-pagespeed-stable-1.12.34.3.tar.bz2?raw=true | tar -jx && \
     curl -L https://github.com/pagespeed/ngx_pagespeed/archive/v${NGX_PAGESPEED_VERSION}-stable.tar.gz | tar -zx && \
     cd /tmp/modpagespeed-${PAGESPEED_VERSION} && \
     curl -L https://raw.githubusercontent.com/We-Amp/ngx-pagespeed-alpine/master/patches/automatic_makefile.patch | patch -p1 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM alpine:3.6
 
 # Inspired by wernight/docker-alpine-nginx-pagespeed
 
-ENV PAGESPEED_VERSION 1.12.34.3
-ENV PAGESPEED_BRANCH stable
-ENV NGINX_VERSION 1.12.2
-ENV LIBPNG_VERSION 1.2.59
+ARG PAGESPEED_VERSION=1.12.34.3
+ARG PAGESPEED_BRANCH=stable
+ARG NGINX_VERSION=1.12.2
+ARG LIBPNG_VERSION=1.2.59
 
 RUN apk --no-cache add \
         ca-certificates \

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 ngx_pagespeed Dockerfile for Alpine, based on wernight/docker-alpine-nginx-pagespeed
 
 ## Docker base
-This image is based on Alpine Linux version 3.4
+This image is based on Alpine Linux version 3.6
 
 ## Pagespeed Components:
 ### mod-pagespeed
-Custom built beta release tarball of mod-pagespeed (mod-pagespeed-beta-1.12.34.3.tar.bz2 uploaded in this repo). This custom tarball includes the upgraded GRPC version(1.4.5) which is required for the Alpine build.
+Custom built beta release tarball of mod-pagespeed (mod-pagespeed-stable-1.12.34.3.tar.bz2 uploaded in this repo). This custom tarball includes the upgraded GRPC version(1.4.5) which is required for the Alpine build.
 ### ngx-pagespeed
 Stable ngx-pagespeed version 1.12.34.3 fetched from [ngx pagespeed archive](https://github.com/pagespeed/ngx_pagespeed/archive/v1.12.34.3-stable.tar.gz).
 ### Nginx
-Stable NGINX version 1.12.1 fetched from [nginx.org](http://nginx.org/download/nginx-1.12.1.tar.gz) .
+Stable NGINX version 1.12.2 fetched from [nginx.org](http://nginx.org/download/nginx-1.12.2.tar.gz) .
 
 ## Using the Dockerfile
 ### Use docker build command to build an image from dockerfile:
@@ -23,4 +23,3 @@ Stable NGINX version 1.12.1 fetched from [nginx.org](http://nginx.org/download/n
 
 ## TODO
 - Update the Dockerfile to use the official mod-pagespeed release tarball once it is available and published.
-- Support Alpine Linux version 3.6


### PR DESCRIPTION
- renamed mod-pagespeed-beta to mod-pagespeed-stable as suggested: We-Amp/ngx-pagespeed-alpine#4
- adjusted versions in ReadMe.md
- As a suggestion, use `ENV` in the Dockerfile to set versions.
- Create nginx user and group.

I use my own nginx.conf, so I have another cache and log dir but have added it back.